### PR TITLE
Update Console.cs, fixed bug with text when console is a child to a window

### DIFF
--- a/Source/Controls/Code/Console.cs
+++ b/Source/Controls/Code/Console.cs
@@ -511,6 +511,7 @@ namespace TomShane.Neoforce.Controls
 					{
 						{
 							int x = 4;
+							if (this.IsChild == true) { x = 12; } else { x = 4; }
 							int y = r.Bottom - (pos + 1) * ((int)font.LineSpacing + 0);
 
 							string msg = ((ConsoleMessage)b[i]).Text;


### PR DESCRIPTION
Small fix for bug when text is too far on the left(first letters are not visible) when console is added as a child to a window.
Not tested on other parents than window.
